### PR TITLE
Fixed %appdata% string

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This theme is up to date as of Unicode 12.0.
 ## Installation
 
 Copy the `android-emoji-theme` folder to
-`~/.purple/smileys` on Linux, or `%APPDATA%/Roaming/.purple/smileys` on Windows.
+`~/.purple/smileys` on Linux, or `%APPDATA%/.purple/smileys` on Windows.
 For Adium on Mac, copy and rename the folder to
 `~/Library/Application\ Support/Adium\ 2.0/Emoticons/android-emoji-theme.AdiumEmoticonSet`.
 


### PR DESCRIPTION
On windows %appdata% points to appdata\roaming in Vista and later